### PR TITLE
Change POST_BUILD for h5watch-files to custom target and commands.

### DIFF
--- a/hl/tools/h5watch/CMakeTests.cmake
+++ b/hl/tools/h5watch/CMakeTests.cmake
@@ -56,18 +56,13 @@ set (H5WATCH_TEST_FILES
 
 # make test dir
 file (MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles")
-add_custom_target(h5watch-files ALL COMMENT "Copying files needed by h5watch tests")
 
 foreach (h5watch_file ${H5WATCH_TEST_FILES})
-  set (dest "${PROJECT_BINARY_DIR}/testfiles/${h5watch_file}")
-  #message (STATUS " Copying ${h5watch_file}")
-  add_custom_command (
-      TARGET     h5watch-files
-      POST_BUILD
-      COMMAND    ${CMAKE_COMMAND}
-      ARGS       -E copy_if_different ${HDF5_HL_TOOLS_DIR}/testfiles/${h5watch_file} ${dest}
-  )
+  HDFTEST_COPY_FILE("${HDF5_HL_TOOLS_DIR}/testfiles/${h5watch_file}" "${PROJECT_BINARY_DIR}/testfiles/${h5watch_file}" "h5watch-files_files")
 endforeach ()
+
+add_custom_target(h5watch-files_files ALL COMMENT "Copying files needed by h5watch-files tests" DEPENDS ${h5watch-files_files_list})
+
 
 ##############################################################################
 ##############################################################################


### PR DESCRIPTION
This keeps the command line from getting too long with the ninja generator.  This fix was done for most but not all of the targets in hdf5.  With this change, it builds again with ninja on Windows.