### PR TITLE
Set CMake policy CMP0075

### DIFF
--- a/config/cmake/ConfigureChecks.cmake
+++ b/config/cmake/ConfigureChecks.cmake
@@ -10,6 +10,11 @@
 # help@hdfgroup.org.
 #
 #-----------------------------------------------------------------------------
+if(POLICY CMP0075)
+  cmake_policy(SET CMP0075 NEW) # CMake 3.12.1: Include file check macros honor CMAKE_REQUIRED_LIBRARIES.
+endif()
+
+#-----------------------------------------------------------------------------
 # Include all the necessary files for macros
 #-----------------------------------------------------------------------------
 set (HDF_PREFIX "H5")

--- a/config/cmake_ext_mod/HDFUseCXX.cmake
+++ b/config/cmake_ext_mod/HDFUseCXX.cmake
@@ -12,6 +12,11 @@
 #
 # This file provides functions for C++ support.
 #
+#-----------------------------------------------------------------------------
+if(POLICY CMP0075)
+  cmake_policy(SET CMP0075 NEW) # CMake 3.12.1: Include file check macros honor CMAKE_REQUIRED_LIBRARIES.
+endif()
+
 #-------------------------------------------------------------------------------
 ENABLE_LANGUAGE (CXX)
 set (HDF_PREFIX "H5")


### PR DESCRIPTION
Since CMake 3.12.1 the following warning is raised if
CMP0075 is not set in the changed files.

```
 CMake Warning (dev) at /usr/share/cmake-3.12/Modules/CheckIncludeFile.cmake:70 (message):
   Policy CMP0075 is not set: Include file check macros honor
   CMAKE_REQUIRED_LIBRARIES.  Run "cmake --help-policy CMP0075" for policy
   details.  Use the cmake_policy command to set the policy and suppress this
   warning.

   CMAKE_REQUIRED_LIBRARIES is set to:

     m;dl

   For compatibility with CMake 3.11 and below this check is ignoring it.
 Call Stack (most recent call first):
   /usr/share/cmake-3.12/Modules/CheckTypeSize.cmake:225 (check_include_file)
   /usr/share/cmake-3.12/Modules/TestBigEndian.cmake:32 (CHECK_TYPE_SIZE)
   config/cmake_ext_mod/ConfigureChecks.cmake:138 (TEST_BIG_ENDIAN)
   config/cmake/ConfigureChecks.cmake:16 (include)
   CMakeLists.txt:408 (include)
 This warning is for project developers.  Use -Wno-dev to suppress it.
```